### PR TITLE
RenovateのPR数上限緩和

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   ],
   "timezone": "Asia/Tokyo",
   "schedule": ["every weekend"],
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 15,
   "automerge": false,
   "rangeStrategy": "bump",
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
## 概要

RenovateのPR作成数上限の引き上げ

## 変更点

RenovateのPR数上限を10 -> 15に変更