### PR TITLE
Reactのアップデート抑止

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,11 @@
       "description": "Disable updates for overrides section",
       "matchDepTypes": ["overrides", "pnpm.overrides"],
       "enabled": false
+    },
+    {
+      "description": "Disable react updates until stable version",
+      "matchPackageNames": ["react", "react-dom"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## 概要

Next.js 15ではReactのpreview版を用いるが、バージョンがハッシュ値であり順番に並んでおらず、バージョンが巻き戻るためアップデートを抑止